### PR TITLE
setuptools requires version <45 for python2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
 ENV pip_packages "wheel cryptography ansible"
 
 # Install Ansible via pip.
-RUN pip install --upgrade pip setuptools \
+RUN pip install --upgrade pip setuptools==44.1.1 \
     && pip install $pip_packages
 
 COPY initctl_faker .


### PR DESCRIPTION
as mentioned in https://github.com/pypa/setuptools/blob/v47.0.0/CHANGES.rst

### Description
The current Dockerfile breaks with a "Syntax error" in the pip upgrade step.
This is because latest setuptools require python 3.
I worked through the changelog and found the mentioned link where they state, that you need to use setuptools <45.
So here we go.
Yes, debian 8 is (almost) eol but I need this still for some regression tests :)